### PR TITLE
=doc Fix comment in Backoff Supervisor example

### DIFF
--- a/akka-docs/rst/scala/code/docs/pattern/BackoffSupervisorDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/pattern/BackoffSupervisorDocSpec.scala
@@ -86,7 +86,7 @@ class BackoffSupervisorDocSpec {
         minBackoff = 3.seconds,
         maxBackoff = 30.seconds,
         randomFactor = 0.2 // adds 20% "noise" to vary the intervals slightly
-      ).withAutoReset(10.seconds) // the child must send BackoffSupervisor.Reset to its parent
+      ).withAutoReset(10.seconds) // reset if the child does not throw any errors within 10 seconds
         .withSupervisorStrategy(
           OneForOneStrategy() {
             case _: MyException => SupervisorStrategy.Restart


### PR DESCRIPTION
```scala
val supervisor = BackoffSupervisor.props(
  Backoff.onFailure(
    childProps,
    childName = "myEcho",
    minBackoff = 3.seconds,
    maxBackoff = 30.seconds,
    randomFactor = 0.2 // adds 20% "noise" to vary the intervals slightly
  ).withAutoReset(10.seconds) // the child must send BackoffSupervisor.Reset to its parent
    .withSupervisorStrategy(
      OneForOneStrategy() {
        case _: MyException => SupervisorStrategy.Restart
        case _              => SupervisorStrategy.Escalate
      }))
```

>  // the child must send BackoffSupervisor.Reset to its parent

is not correct because it happens when we use `withManualReset`. Change to:

> // reset if the child does not throw any errors within 10 seconds

```scala
val supervisor = BackoffSupervisor.props(
      Backoff.onFailure(
        childProps,
        childName = "myEcho",
        minBackoff = 3.seconds,
        maxBackoff = 30.seconds,
        randomFactor = 0.2 // adds 20% "noise" to vary the intervals slightly
      ).withAutoReset(10.seconds) // reset if the child does not throw any errors within 10 seconds
        .withSupervisorStrategy(
          OneForOneStrategy() {
            case _: MyException => SupervisorStrategy.Restart
            case _              => SupervisorStrategy.Escalate
          }))
```